### PR TITLE
huggingface_konlpy install fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ torch==1.7.0
 tqdm==4.52.0
 transformers==3.5.1
 mecab-python===0.996-ko-0.9.2
-huggingface-konlpy==0.1.0
+git+git://github.com/krevas/huggingface_konlpy


### PR DESCRIPTION
- requirements.txt에서 huggingface_konlpy 수정
- 기존 https://github.com/lovit/huggingface_konlpy 의 requirements.txt에는 버전이 명시되어있어 설치시 버전 충돌 오류 발생함
- 특정 버전이 반드시 필요한건 아니기 때문에 버전 표기 삭제 및 불필요한 라이브러리 삭제함
- 수정된 fork repository로 requirements.txt 변경함